### PR TITLE
Migration to trakt V2 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.project
+/.pydevproject
+/.settings

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.project
 /.pydevproject
 /.settings
+*.pyc

--- a/addon.py
+++ b/addon.py
@@ -446,15 +446,19 @@ def get_api():
     api = TraktListApi()
     while not logged_in:
         try:
-            logged_in = api.connect(
+            token = api.connect(
                 username=plugin.get_setting('username', unicode),
                 password=plugin.get_setting('password', unicode),
+                token=plugin.get_setting('trakt_token', unicode),
                 api_key=API_KEY,
                 use_https=plugin.get_setting('use_https', bool),
             )
+            plugin.set_setting('trakt_token', token)
+            logged_in = True
         except AuthenticationError:
-            logged_in = False
-        if not logged_in:
+            token = ''
+        
+        if not token:
             try_again = xbmcgui.Dialog().yesno(
                 _('connection_error'),
                 _('wrong_credentials'),

--- a/addon.xml
+++ b/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.trakt_list_manager" name="Trakt.tv List Manager" version="0.1.4" provider-name="Tristan Fischer (sphere@dersphere.de)">
+<addon id="plugin.video.trakt_list_manager" name="Trakt.tv List Manager" version="0.1.5~alpha" provider-name="Tristan Fischer (sphere@dersphere.de)">
     <requires>
         <import addon="xbmc.python" version="2.1.0"/>
         <import addon="script.module.xbmcswift2" version="2.4.0"/>

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,6 @@
+0.1.5 (02.02.2015)
+- Migrate trakt api to V2
+
 0.1.4 (08.01.2014)
  - fix adding or deleting of movies with only tmdb_id or imdb_id
  - fix urlencoding bug (e.g. on movies with colon in title

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -5,4 +5,5 @@
     <setting id="use_https" type="bool" label="30303" default="true" />
     <setting id="default_privacy" type="enum" label="30310" default="0" lvalues="30311|30312|30313"/>
     <setting id="default_list" type="action" label="30302" action="RunPlugin(plugin://plugin.video.trakt_list_manager/settings/default_list)"/>
+    <setting id="trakt_token" type="text" visible="false"/>
 </settings>


### PR DESCRIPTION
These changes migrate this addon to use the V2 trakt api. The V1 API is basically shutdown now so this addon was broken. Since it's very useful with the Apple Itunes Trailer addon which I also used I made the changes needed.

I've tested all functions as well as verifying that the plugin:// urls work.

The only thing that significantly different than before is the new API requires a token rather than the hashed password so I added code to persist the token and only re-request it when you get an auth error.

Also, the way the API reports success or failure now is not in the json response but instead in the HTTP Status codes so I changed that as well.